### PR TITLE
Fix: Replace JSON response with EJS template for /profile route

### DIFF
--- a/middlewares/is_authenticated.js
+++ b/middlewares/is_authenticated.js
@@ -6,15 +6,15 @@ const isAuthenticated = async (req, res, next) => {
     try {
         const token = req.cookies.token;
         if (!token) {
-            return res.status(401).json({
-                message: "User not authenticated",
+            return res.status(401).render('login', {
+                message: "Please log in to access your profile",
                 success: false,
             })
         }
         const decode = await jwt.verify(token, SECRET_KEY);
         if(!decode){
-            return res.status(401).json({
-                message:"Invalid token",
+            return res.status(401).render('login', {
+                message:"Session expired. Please log in again.",
                 success:false
             })
         };

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -37,6 +37,14 @@
         <div class="form_wrapper shadow">
             <div class="my_form">
                 <h3 class="register_btn">Login</h3>
+                
+                <!-- Display message if provided -->
+                <% if (typeof message !== 'undefined' && message) { %>
+                <div class="alert alert-warning" style="background-color: #fff3cd; border: 1px solid #ffc107; color: #856404; padding: 10px; border-radius: 5px; margin-bottom: 15px;">
+                    <%= message %>
+                </div>
+                <% } %>
+                
                 <form action="/login" method="POST">
                     <!-- Role Dropdown -->
                     <div class="mt-10">


### PR DESCRIPTION
## Summary
This PR fixes issue #2 by replacing the raw JSON response with a rendered EJS template when unauthenticated users access the /profile route.

## Changes Made
1. **middlewares/is_authenticated.js**: 
   - Changed from returning JSON () to rendering the login page ()
   - Added user-friendly messages:
     - "Please log in to access your profile" (when no token)
     - "Session expired. Please log in again." (when invalid token)

2. **views/login.ejs**:
   - Added message display section that shows authentication-related messages
   - Styled with Bootstrap-like alert styling

## Before
Accessing  without authentication returned:
```json
{"message": "User not authenticated", "success": false}
```

## After
Accessing  without authentication now renders the login page with a helpful message prompting the user to log in.

## Testing
- [x] Accessing /profile without a token shows login page with message
- [x] Accessing /profile with invalid token shows login page with session expired message
- [x] Login page displays messages correctly when provided

## Related Issue
Fixes #2

---
**Bounty**: This PR addresses the requirements in issue #2 for improving UX by rendering a proper UI instead of raw JSON responses.